### PR TITLE
feat(GDB-10457) Add endpoint Prop to GraphQL Playground Component

### DIFF
--- a/ontotext-graphql-playground-component/cypress.config.js
+++ b/ontotext-graphql-playground-component/cypress.config.js
@@ -4,6 +4,7 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3333/',
     videoUploadOnPasses: false,
+    fixturesFolder: 'cypress/fixtures',
     video: false,
     setupNodeEvents(on, config) {
       // Any necessary node event setup

--- a/ontotext-graphql-playground-component/cypress/e2e/default-view.spec.cy.ts
+++ b/ontotext-graphql-playground-component/cypress/e2e/default-view.spec.cy.ts
@@ -1,14 +1,37 @@
+/// <reference types="cypress" />
 import DefaultViewPageSteps from "../steps/default-view-page-steps";
+import PlaygroundEditorSteps from "../steps/playground-editor-steps";
+import {stubQuery} from "../utils/graphql-test.util";
 
 describe('Default view', () => {
-
+  const graphqlEndpoint = '/rest/repositories/test/graphql/graphql-test-endpoint';
   beforeEach(() => {
+    cy.intercept('POST', graphqlEndpoint, (req) => {
+      stubQuery(req, 'IntrospectionQuery', 'empty.json');
+      stubQuery(req, 'TestQuery', {
+        data: {
+          testField: 'TestValue',
+        },
+      });
+    });
+
     DefaultViewPageSteps.visit();
   });
 
   it('Should load component with default configuration', () => {
     // When I visit the playground page
     DefaultViewPageSteps.getPlayground().should('exist').and('be.visible');
-    DefaultViewPageSteps.getExecuteButton().should('be.visible').and('be.enabled');
+    PlaygroundEditorSteps.getExecuteButton().should('be.visible').and('be.enabled');
+  });
+
+  it('should call the GraphQL endpoint with the correct query', () => {
+    DefaultViewPageSteps.getPlayground().should('exist').and('be.visible');
+    // When I set a query
+    PlaygroundEditorSteps.setInEditor('query TestQuery {\n testField\n}');
+    // And I execute the query
+    PlaygroundEditorSteps.executeQuery();
+    // Then I get expected result
+    PlaygroundEditorSteps.getResponse().should('contain', '"testField": "TestValue"');
   });
 });
+

--- a/ontotext-graphql-playground-component/cypress/fixtures/empty.json
+++ b/ontotext-graphql-playground-component/cypress/fixtures/empty.json
@@ -1,0 +1,30 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "fields": [
+            {
+              "name": "testField",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        }
+      ],
+      "directives": []
+    }
+  }
+}

--- a/ontotext-graphql-playground-component/cypress/steps/default-view-page-steps.ts
+++ b/ontotext-graphql-playground-component/cypress/steps/default-view-page-steps.ts
@@ -1,13 +1,10 @@
+/// <reference types="cypress" />
 export default class DefaultViewPageSteps {
   static visit() {
     cy.visit('/pages/default-view');
   }
 
   static getPlayground() {
-    return cy.get('#graphiql');
-  }
-
-  static getExecuteButton() {
-    return this.getPlayground().find('.graphiql-execute-button');
+    return cy.get('.graphiql-query-editor textarea');
   }
 }

--- a/ontotext-graphql-playground-component/cypress/steps/playground-editor-steps.ts
+++ b/ontotext-graphql-playground-component/cypress/steps/playground-editor-steps.ts
@@ -1,0 +1,40 @@
+/// <reference types="cypress" />
+export default class PlaygroundEditorSteps {
+  static getQueryEditor() {
+    return cy.get('.graphiql-query-editor textarea');
+}
+
+  static setInEditor(text: string) {
+    return cy.window()
+      .then((win) => {
+        // @ts-ignore CodeMirror is undefined
+        const codeMirrorInstance = win.document.querySelector('.CodeMirror').CodeMirror;
+        codeMirrorInstance.setValue(text);
+      });
+  }
+
+  static clear() {
+    PlaygroundEditorSteps.setInEditor('');
+  }
+
+  static getEditorContent() {
+    return cy.window().then((win) => {
+      // @ts-ignore CodeMirror is undefined
+      const codeMirrorInstance = win.document.querySelector('.CodeMirror').CodeMirror;
+      return codeMirrorInstance.getValue();
+    });
+  }
+
+  static getExecuteButton() {
+    return cy.get('.graphiql-execute-button');
+  }
+
+  static executeQuery(delay = 150) {
+    cy.wait(delay);
+    return PlaygroundEditorSteps.getExecuteButton().click();
+  }
+
+  static getResponse() {
+    return cy.get('.graphiql-response');
+  }
+}

--- a/ontotext-graphql-playground-component/cypress/utils/graphql-test.util.ts
+++ b/ontotext-graphql-playground-component/cypress/utils/graphql-test.util.ts
@@ -1,0 +1,112 @@
+const defaultHeaders = {
+  'api-timestamp': '123456789'
+};
+
+/**
+ * Utility to match a GraphQL mutation or query based on the operation name.
+ *
+ * @param {any} req - The request object.
+ * @param {string} operationName - The name of the GraphQL operation to match.
+ * @returns {boolean} True if the request's operation name matches the provided name, otherwise false.
+ */
+export const hasOperationName = (req: any, operationName: string): boolean => {
+  const {body} = req;
+  return (
+    body.hasOwnProperty('operationName') && body.operationName === operationName
+  );
+};
+
+/**
+ * Utility to check if a GraphQL request contains the specified variables.
+ *
+ * @param {any} req - The request object.
+ * @param {object} variables - The variables to match in the request.
+ * @returns {boolean} True if the request contains the specified variables, otherwise false.
+ */
+export const hasVariables = (req: any, variables: any): boolean => {
+  const {body} = req;
+  if (body.hasOwnProperty('variables')) {
+    let sameVars = false;
+    Object.keys(variables).forEach((name) => {
+      if (Array.isArray(variables[name])) {
+        sameVars = body.variables[name] !== undefined && variables[name].toString() === body.variables[name].toString();
+      } else {
+        sameVars = body.variables[name] !== undefined && body.variables[name] === variables[name];
+      }
+    });
+    return sameVars;
+  }
+  return false;
+};
+
+/**
+ * Aliases a query request if its operation name matches the provided name.
+ *
+ * @param {any} req - The request object.
+ * @param {string} operationName - The name of the GraphQL query to alias.
+ */
+export const aliasQuery = (req: any, operationName: string): void => {
+  if (hasOperationName(req, operationName)) {
+    req.alias = operationName;
+  }
+};
+
+/**
+ * Stubs a GraphQL query request with a specified fixture, status code, and optional headers and delay.
+ *
+ * @param {any} req - The request object.
+ * @param {string} operationName - The name of the GraphQL query to stub.
+ * @param {any} fixture - The fixture to return as a response.
+ * @param {number} [statusCode=200] - The HTTP status code for the response.
+ * @param {number} [delay=0] - The delay in milliseconds before sending the response.
+ * @param {object} [headers={}] - Optional headers to include in the response.
+ */
+export const stubQuery = (req: any, operationName: string, fixture: any, statusCode = 200, delay = 0, headers: { [key: string]: string } = {}): void => {
+  if (hasOperationName(req, operationName)) {
+    const requestHeaders = {...defaultHeaders, ...headers};
+    req.alias = operationName;
+    req.reply({
+      statusCode,
+      body:fixture,
+      headers: requestHeaders,
+      delay
+    });
+  }
+};
+
+/**
+ * Stubs a GraphQL query request with specific variables, using a fixture, delay, and optional headers.
+ *
+ * @param {any} req - The request object.
+ * @param {string} operationName - The name of the GraphQL query to stub.
+ * @param {object} variables - The variables to match in the request.
+ * @param {any} fixture - The fixture to return as a response.
+ * @param {number} [delay=0] - The delay in milliseconds before sending the response.
+ * @param {object} [headers={}] - Optional headers to include in the response.
+ */
+export const stubQueryWithVariable = (req: any, operationName: string, variables: any, fixture: any, delay = 0, headers: { [key: string]: string } = {}): void => {
+  if (hasOperationName(req, operationName) && hasVariables(req, variables)) {
+    const requestHeaders = {...defaultHeaders, ...headers};
+    req.alias = operationName;
+    const replyConfig = {
+      statusCode: 200, // default
+      fixture,
+      headers: requestHeaders,
+      delay
+    };
+    req.reply(replyConfig);
+  }
+};
+
+/**
+ * Aliases a mutation request if its operation name matches the provided name.
+ *
+ * @param {any} req - The request object.
+ * @param {string} operationName - The name of the GraphQL mutation to alias.
+ */
+export const aliasMutation = (req: any, operationName: string): void => {
+  if (hasOperationName(req, operationName)) {
+    req.alias = operationName;
+  }
+};
+

--- a/ontotext-graphql-playground-component/package-lock.json
+++ b/ontotext-graphql-playground-component/package-lock.json
@@ -777,9 +777,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
-      "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
+      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1326,9 +1326,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1558,9 +1558,9 @@
       }
     },
     "node_modules/@stencil/angular-output-target": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.10.0.tgz",
-      "integrity": "sha512-j/VXofXggbqzfzX6+1F++IZbGNfEKw1eQAdd5S4PpjGGWsf0TI6qDBd4YrjCMHAKCSV18FNuKFBejejM/49T/Q==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.10.1.tgz",
+      "integrity": "sha512-cH9LD4IMz0KZ36lRAcIBpXXJq4fVHk23cnkVyIrCK/DBnnCPz2jNqpUfOB+/a6lHnZd/XyciCVUVEBQXPyRqxg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1568,9 +1568,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.22.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.22.3.tgz",
-      "integrity": "sha512-dYaletX938WgEA2oMROLdh8wpUn1MgBx2zg5kYqwuUR8aua4Gy9EqGQ3zBu1AvL5MzLlZC+lMlxe/g5Dg1ldpw==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.23.0.tgz",
+      "integrity": "sha512-9vI8ywhoqlaDEmrcntejrZ9X76Tddv2JyWakjVpqJAdDNXgf520sYkyjzGT0p8VJfPtSaKm6pMtl5sAH1r9cFg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1773,17 +1773,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.0.tgz",
-      "integrity": "sha512-NR2yS7qUqCL7AIxdJUQf2MKKNDVNaig/dEB0GBLU7D+ZdHgK1NoH/3wsgO3OnPVipn51tG3MAwaODEGil70WEw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.1.tgz",
+      "integrity": "sha512-Ncvsq5CT3Gvh+uJG0Lwlho6suwDfUXH0HztslDf5I+F2wAFAZMRwYLEorumpKLzmO2suAXZ/td1tBg4NZIi9CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/type-utils": "8.18.0",
-        "@typescript-eslint/utils": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/scope-manager": "8.18.1",
+        "@typescript-eslint/type-utils": "8.18.1",
+        "@typescript-eslint/utils": "8.18.1",
+        "@typescript-eslint/visitor-keys": "8.18.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1803,16 +1803,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.0.tgz",
-      "integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.1.tgz",
+      "integrity": "sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==",
       "dev": true,
-      "license": "MITClause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/typescript-estree": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/scope-manager": "8.18.1",
+        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/typescript-estree": "8.18.1",
+        "@typescript-eslint/visitor-keys": "8.18.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1828,14 +1828,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.0.tgz",
-      "integrity": "sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.1.tgz",
+      "integrity": "sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0"
+        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/visitor-keys": "8.18.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1846,14 +1846,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.0.tgz",
-      "integrity": "sha512-er224jRepVAVLnMF2Q7MZJCq5CsdH2oqjP4dT7K6ij09Kyd+R21r7UVJrF0buMVdZS5QRhDzpvzAxHxabQadow==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.1.tgz",
+      "integrity": "sha512-jAhTdK/Qx2NJPNOTxXpMwlOiSymtR2j283TtPqXkKBdH8OAMmhiUfP0kJjc/qSE51Xrq02Gj9NY7MwK+UxVwHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.18.0",
-        "@typescript-eslint/utils": "8.18.0",
+        "@typescript-eslint/typescript-estree": "8.18.1",
+        "@typescript-eslint/utils": "8.18.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -1870,9 +1870,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.0.tgz",
-      "integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.1.tgz",
+      "integrity": "sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1884,14 +1884,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.0.tgz",
-      "integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.1.tgz",
+      "integrity": "sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/visitor-keys": "8.18.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1911,16 +1911,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.0.tgz",
-      "integrity": "sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.1.tgz",
+      "integrity": "sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/typescript-estree": "8.18.0"
+        "@typescript-eslint/scope-manager": "8.18.1",
+        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/typescript-estree": "8.18.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1935,13 +1935,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.0.tgz",
-      "integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.1.tgz",
+      "integrity": "sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/types": "8.18.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -2190,17 +2190,17 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2210,17 +2210,17 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2248,21 +2248,20 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
-        "es-errors": "^1.2.1",
-        "get-intrinsic": "^1.2.3",
-        "is-array-buffer": "^3.0.4",
-        "is-shared-array-buffer": "^1.0.2"
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2580,9 +2579,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
+      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
       "dev": true,
       "funding": [
         {
@@ -2600,9 +2599,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001669",
-        "electron-to-chromium": "^1.5.41",
-        "node-releases": "^2.0.18",
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.1"
       },
       "bin": {
@@ -2693,6 +2692,7 @@
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -2720,6 +2720,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2741,9 +2758,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001687",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
-      "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
+      "version": "1.0.30001689",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001689.tgz",
+      "integrity": "sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==",
       "dev": true,
       "funding": [
         {
@@ -3308,6 +3325,7 @@
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3384,13 +3402,13 @@
       }
     },
     "node_modules/dunder-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
-      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
         "gopd": "^1.2.0"
       },
@@ -3410,9 +3428,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.72",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.72.tgz",
-      "integrity": "sha512-ZpSAUOZ2Izby7qnZluSrAlGgGQzucmFbN0n64dYzocYxnxV5ufurpj3VgEe4cUp7ir9LmeLxNYo8bVnlM8bQHw==",
+      "version": "1.5.74",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.74.tgz",
+      "integrity": "sha512-ck3//9RC+6oss/1Bh9tiAVFy5vfSKbRHAFh7Z3/eTRkEqJeWgymloShB17Vg3Z4nmDNp35vAd1BZ6CMW4Wt6Iw==",
       "dev": true,
       "license": "ISC"
     },
@@ -3484,59 +3502,61 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
-      "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
+      "version": "1.23.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.6.tgz",
+      "integrity": "sha512-Ifco6n3yj2tMZDWNLyloZrytt9lqqlwvS83P3HtaETR0NUOYnIULGGHpktqYGObGy+8wc1okO25p8TjemhImvA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
-        "arraybuffer.prototype.slice": "^1.0.3",
+        "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "data-view-buffer": "^1.0.1",
         "data-view-byte-length": "^1.0.1",
         "data-view-byte-offset": "^1.0.0",
-        "es-define-property": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "es-set-tostringtag": "^2.0.3",
-        "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.4",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.7",
+        "get-intrinsic": "^1.2.6",
         "get-symbol-description": "^1.0.2",
         "globalthis": "^1.0.4",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.0.3",
-        "has-symbols": "^1.0.3",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "internal-slot": "^1.0.7",
+        "internal-slot": "^1.1.0",
         "is-array-buffer": "^3.0.4",
         "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.1",
+        "is-data-view": "^1.0.2",
         "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.1.4",
+        "is-regex": "^1.2.1",
         "is-shared-array-buffer": "^1.0.3",
-        "is-string": "^1.0.7",
+        "is-string": "^1.1.1",
         "is-typed-array": "^1.1.13",
-        "is-weakref": "^1.0.2",
+        "is-weakref": "^1.1.0",
+        "math-intrinsics": "^1.0.0",
         "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.5",
         "regexp.prototype.flags": "^1.5.3",
-        "safe-array-concat": "^1.1.2",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.trim": "^1.2.9",
-        "string.prototype.trimend": "^1.0.8",
+        "safe-array-concat": "^1.1.3",
+        "safe-regex-test": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
         "typed-array-buffer": "^1.0.2",
         "typed-array-byte-length": "^1.0.1",
-        "typed-array-byte-offset": "^1.0.2",
-        "typed-array-length": "^1.0.6",
+        "typed-array-byte-offset": "^1.0.3",
+        "typed-array-length": "^1.0.7",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3599,7 +3619,6 @@
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3678,9 +3697,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.16.0.tgz",
-      "integrity": "sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
+      "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3690,7 +3709,7 @@
         "@eslint/config-array": "^0.19.0",
         "@eslint/core": "^0.9.0",
         "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.16.0",
+        "@eslint/js": "9.17.0",
         "@eslint/plugin-kit": "^0.2.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3699,7 +3718,7 @@
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.5",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^8.2.0",
@@ -4431,17 +4450,18 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.7.tgz",
+      "integrity": "sha512-2g4x+HqTJKM9zcJqBSpjoRmdcPFtJM60J3xJisTQSXBWka5XqyBN/2tNUgma1mztTXyDuUsEtYe5qcs7xYzYQA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4482,20 +4502,22 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.5.tgz",
-      "integrity": "sha512-Y4+pKa7XeRUPWFNvOOYHkRYrfzW07oraURSvjDmRVOJ748OrVmeXtpE4+GCEHncjCjkTxPNRt8kEbxDhsn6VTg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.1",
         "dunder-proto": "^1.0.0",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4704,9 +4726,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
-      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
+      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -4739,6 +4761,7 @@
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -5011,31 +5034,32 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5086,14 +5110,14 @@
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.0.tgz",
-      "integrity": "sha512-kR5g0+dXf/+kXnqI+lu0URKYPKgICtHGGNCDSB10AaUFj3o/HkB3u7WfpRBJGFopxxY0oH3ux7ZsDjLtK7xqvw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -5134,9 +5158,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5150,13 +5174,15 @@
       }
     },
     "node_modules/is-data-view": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
         "is-typed-array": "^1.1.13"
       },
       "engines": {
@@ -5167,14 +5193,15 @@
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5194,14 +5221,14 @@
       }
     },
     "node_modules/is-finalizationregistry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.0.tgz",
-      "integrity": "sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5323,14 +5350,14 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.0.tgz",
-      "integrity": "sha512-KVSZV0Dunv9DTPkhXwcZ3Q+tUc9TsaE1ZwX5J2WMvsSGS6Md8TFPun5uwh0yRdrNerI6vf/tbJxqSx4c1ZI1Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -5368,15 +5395,15 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.0.tgz",
-      "integrity": "sha512-B6ohK4ZmoftlUe+uvenXSbPJFo6U37BH7oO1B3nQH8f/7h27N56s85MhUtbFJAziz5dcmuR3i8ovUl35zp8pFA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "gopd": "^1.1.0",
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2",
         "hasown": "^2.0.2"
       },
@@ -5432,14 +5459,14 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.0.tgz",
-      "integrity": "sha512-PlfzajuF9vSo5wErv3MJAKD/nqf9ngAs1NFQYm16nUYFO2IzxJ2hcm+IOCg+EEopdykNNUhVq5cz35cAUxU8+g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -5450,16 +5477,16 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.0.tgz",
-      "integrity": "sha512-qS8KkNNXUZ/I+nX6QT8ZS1/Yx0A444yhzdTKxCzKkNjQ9sHErBxJnJAgh+f5YhusYECEcjo4XcyH87hn6+ks0A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "has-symbols": "^1.0.3",
-        "safe-regex-test": "^1.0.3"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5520,29 +5547,32 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-weakset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4"
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5658,18 +5688,19 @@
       }
     },
     "node_modules/iterator.prototype": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.3.tgz",
-      "integrity": "sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.4.tgz",
+      "integrity": "sha512-x4WH0BWmrMmg4oHHl+duwubhrvczGlyuGAZu3nvrf0UXOfPu8IhZObFEr7DE/iv01YgVZrsOiRcqw2srkKEDIA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "define-properties": "^1.2.1",
-        "get-intrinsic": "^1.2.1",
-        "has-symbols": "^1.0.3",
-        "reflect.getprototypeof": "^1.0.4",
-        "set-function-name": "^2.0.1"
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.8",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6779,6 +6810,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
+      "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7643,13 +7684,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.9",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
+      "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -7795,16 +7836,17 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
       "engines": {
@@ -7836,16 +7878,16 @@
       "license": "MIT"
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
-        "is-regex": "^1.1.4"
+        "is-regex": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7903,6 +7945,7 @@
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -7969,16 +8012,73 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8181,17 +8281,20 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.0",
-        "es-object-atoms": "^1.0.0"
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8201,16 +8304,20 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8374,22 +8481,22 @@
       "license": "MIT"
     },
     "node_modules/tldts": {
-      "version": "6.1.66",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.66.tgz",
-      "integrity": "sha512-l3ciXsYFel/jSRfESbyKYud1nOw7WfhrBEF9I3UiarYk/qEaOOwu3qXNECHw4fHGHGTEOuhf/VdKgoDX5M/dhQ==",
+      "version": "6.1.68",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.68.tgz",
+      "integrity": "sha512-JKF17jROiYkjJPT73hUTEiTp2OBCf+kAlB+1novk8i6Q6dWjHsgEjw9VLiipV4KTJavazXhY1QUXyQFSem2T7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.66"
+        "tldts-core": "^6.1.68"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.66",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.66.tgz",
-      "integrity": "sha512-s07jJruSwndD2X8bVjwioPfqpIc1pDTzszPe9pL1Skbh4bjytL85KNQ3tolqLbCvpQHawIsGfFi9dgerWjqW4g==",
+      "version": "6.1.68",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.68.tgz",
+      "integrity": "sha512-85TdlS/DLW/gVdf2oyyzqp3ocS30WxjaL4la85EArl9cHUR/nizifKAJPziWewSZjDZS71U517/i6ciUeqtB5Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8656,17 +8763,20 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8888,18 +8998,18 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.0.tgz",
-      "integrity": "sha512-Ei7Miu/AXe2JJ4iNF5j/UphAgRoma4trE6PtisM09bPygb3egMH3YLW/befsWb1A1AxvNSFidOFTB18XtnIIng==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.0",
-        "is-number-object": "^1.1.0",
-        "is-string": "^1.1.0",
-        "is-symbol": "^1.1.0"
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8909,26 +9019,26 @@
       }
     },
     "node_modules/which-builtin-type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.0.tgz",
-      "integrity": "sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.2",
         "function.prototype.name": "^1.1.6",
         "has-tostringtag": "^1.0.2",
         "is-async-function": "^2.0.0",
-        "is-date-object": "^1.0.5",
+        "is-date-object": "^1.1.0",
         "is-finalizationregistry": "^1.1.0",
         "is-generator-function": "^1.0.10",
-        "is-regex": "^1.1.4",
+        "is-regex": "^1.2.1",
         "is-weakref": "^1.0.2",
         "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.0.2",
+        "which-boxed-primitive": "^1.1.0",
         "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"

--- a/ontotext-graphql-playground-component/src/components.d.ts
+++ b/ontotext-graphql-playground-component/src/components.d.ts
@@ -5,8 +5,11 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { ExternalGraphqlPlaygroundConfiguration } from "./models/external-graphql-playground-configuration";
+export { ExternalGraphqlPlaygroundConfiguration } from "./models/external-graphql-playground-configuration";
 export namespace Components {
     interface GraphqlPlaygroundComponent {
+        "configuration": ExternalGraphqlPlaygroundConfiguration;
     }
 }
 declare global {
@@ -22,6 +25,7 @@ declare global {
 }
 declare namespace LocalJSX {
     interface GraphqlPlaygroundComponent {
+        "configuration"?: ExternalGraphqlPlaygroundConfiguration;
     }
     interface IntrinsicElements {
         "graphql-playground-component": GraphqlPlaygroundComponent;

--- a/ontotext-graphql-playground-component/src/components/graphql-playground-component/readme.md
+++ b/ontotext-graphql-playground-component/src/components/graphql-playground-component/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property        | Attribute | Description | Type                                     | Default     |
+| --------------- | --------- | ----------- | ---------------------------------------- | ----------- |
+| `configuration` | --        |             | `ExternalGraphqlPlaygroundConfiguration` | `undefined` |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/ontotext-graphql-playground-component/src/index.html
+++ b/ontotext-graphql-playground-component/src/index.html
@@ -7,6 +7,14 @@
 
     <script type="module" src="/build/ontotext-graphql-playground-component.esm.js"></script>
     <script nomodule src="/build/ontotext-graphql-playground-component.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const graphqlPlayground = document.querySelector('graphql-playground-component');
+        if (graphqlPlayground) {
+          graphqlPlayground.configuration = {endpoint: "https://swapi-graphql.netlify.app/.netlify/functions/index"};
+        }
+      });
+    </script>
   </head>
   <body>
     <graphql-playground-component></graphql-playground-component>

--- a/ontotext-graphql-playground-component/src/models/external-graphql-playground-configuration.ts
+++ b/ontotext-graphql-playground-component/src/models/external-graphql-playground-configuration.ts
@@ -1,0 +1,6 @@
+export class ExternalGraphqlPlaygroundConfiguration {
+  /**
+   * The graphql endpoint which will be used when a query request is made.
+   */
+  endpoint: string
+}

--- a/ontotext-graphql-playground-component/src/pages/default-view/index.html
+++ b/ontotext-graphql-playground-component/src/pages/default-view/index.html
@@ -7,8 +7,16 @@
 
     <script type="module" src="/build/ontotext-graphql-playground-component.esm.js"></script>
     <script nomodule src="/build/ontotext-graphql-playground-component.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const graphqlPlayground = document.querySelector('graphql-playground-component');
+        if (graphqlPlayground) {
+          graphqlPlayground.configuration = { endpoint: "/rest/repositories/test/graphql/graphql-test-endpoint" };
+        }
+      });
+    </script>
   </head>
   <body>
-  <graphql-playground-component></graphql-playground-component>
+    <graphql-playground-component></graphql-playground-component>
   </body>
 </html>

--- a/ontotext-graphql-playground-component/stencil.config.ts
+++ b/ontotext-graphql-playground-component/stencil.config.ts
@@ -41,6 +41,7 @@ export const config: Config = {
           src: 'components/assets',
           dest: 'build/assets',
         },
+        {src: 'pages'},
       ]
     },
     angularOutputTarget({


### PR DESCRIPTION
## WHAT
- Introduced a new endpoint property
- Updated the index.html to use the endpoint prop with a default GraphQL API URL.
- Refactored the graphql-playground-component.tsx to dynamically use the endpoint prop

## WHY
- To enable dynamic configuration of the GraphQL API endpoint

## HOW
- Declared a new @Prop() decorator
- Updated the componentDidLoad lifecycle method to use the endpoint property
- Adjusted the index.html to include a sample endpoint for demonstration purposes.