### PR TITLE
GDB-11463 allow http headers to be configured

### DIFF
--- a/ontotext-graphql-playground-component/cypress/e2e/configuration.spec.cy.ts
+++ b/ontotext-graphql-playground-component/cypress/e2e/configuration.spec.cy.ts
@@ -47,5 +47,39 @@ describe('Component configuration', () => {
     // Then I get expected result from the new endpoint
     PlaygroundEditorSteps.getResponse().should('contain', '"name": "Morty Smith"');
   });
+
+  it('Should be able to set or remove request headers', () => {
+    // Given that by default there are no headers provided with the configuration
+    // When I set a query
+    PlaygroundEditorSteps.setInEditor(`
+      query GetContinentById {
+        continent(code: "EU") {
+          name
+        }
+      }
+    `);
+    // And I execute the query
+    PlaygroundEditorSteps.executeQuery();
+    // Then I expect the request to not contain my expected header
+    cy.wait('@countries').its('request.headers').should('not.have.a.property', 'authorization');
+
+    // When I set request headers
+    ComponentConfigurationViewPageSteps.setHeaders();
+    // when config is changed, the playground performs a new introspection query
+    cy.wait('@countries');
+    // And I execute the query
+    PlaygroundEditorSteps.executeQuery();
+    // Then I expect the request to contain my expected header
+    cy.wait('@countries').its('request.headers').should('have.a.property', 'authorization');
+
+    // When I remove the headers
+    ComponentConfigurationViewPageSteps.removeHeaders();
+    // when config is changed, the playground performs a new introspection query
+    cy.wait('@countries');
+    // And I execute the query
+    PlaygroundEditorSteps.executeQuery();
+    // Then I expect the request to not contain my expected header
+    cy.wait('@countries').its('request.headers').should('not.have.a.property', 'authorization');
+  });
 });
 

--- a/ontotext-graphql-playground-component/cypress/steps/component-configuration-view-page-steps.ts
+++ b/ontotext-graphql-playground-component/cypress/steps/component-configuration-view-page-steps.ts
@@ -11,4 +11,12 @@ export class ComponentConfigurationViewPageSteps {
   static changeEndpoint(): void {
     cy.get('#changeEndpointButton').click();
   }
+
+  static setHeaders(): void {
+    cy.get('#addHeadersButton').click();
+  }
+
+  static removeHeaders(): void {
+    cy.get('#removeHeadersButton').click();
+  }
 }

--- a/ontotext-graphql-playground-component/cypress/steps/playground-editor-steps.ts
+++ b/ontotext-graphql-playground-component/cypress/steps/playground-editor-steps.ts
@@ -1,10 +1,10 @@
 /// <reference types="cypress" />
 export default class PlaygroundEditorSteps {
-  static getQueryEditor() {
+  static getQueryEditor(): Cypress.Chainable {
     return cy.get('.graphiql-query-editor textarea');
 }
 
-  static setInEditor(text: string) {
+  static setInEditor(text: string): Cypress.Chainable {
     return cy.window()
       .then((win) => {
         // @ts-ignore CodeMirror is undefined
@@ -13,11 +13,11 @@ export default class PlaygroundEditorSteps {
       });
   }
 
-  static clear() {
+  static clear(): void {
     PlaygroundEditorSteps.setInEditor('');
   }
 
-  static getEditorContent() {
+  static getEditorContent(): Cypress.Chainable {
     return cy.window().then((win) => {
       // @ts-ignore CodeMirror is undefined
       const codeMirrorInstance = win.document.querySelector('.CodeMirror').CodeMirror;
@@ -25,16 +25,16 @@ export default class PlaygroundEditorSteps {
     });
   }
 
-  static getExecuteButton() {
+  static getExecuteButton(): Cypress.Chainable {
     return cy.get('.graphiql-execute-button');
   }
 
-  static executeQuery(delay = 150) {
+  static executeQuery(delay = 150): Cypress.Chainable {
     cy.wait(delay);
     return PlaygroundEditorSteps.getExecuteButton().click();
   }
 
-  static getResponse() {
+  static getResponse(): Cypress.Chainable {
     return cy.get('.graphiql-response');
   }
 }

--- a/ontotext-graphql-playground-component/src/components/graphql-playground-component/graphql-playground-component.tsx
+++ b/ontotext-graphql-playground-component/src/components/graphql-playground-component/graphql-playground-component.tsx
@@ -85,17 +85,15 @@ export class GraphqlPlaygroundComponent {
       // @ts-ignore
       this.reactRoot = ReactDOM.createRoot(containerEl);
     }
-    // @ts-ignore
-    const fetcher = GraphiQL.createFetcher({
-      url: configuration.endpoint,
-    });
+
+    const fetcher = this.getFetcher(configuration);
     // @ts-ignore
     const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
     this.reactRoot.render(
       // @ts-ignore
       React.createElement(GraphiQL, {
         fetcher,
-        defaultEditorToolsVisibility: true,
+        defaultEditorToolsVisibility: false,
         plugins: [explorerPlugin],
       }),
     );
@@ -114,5 +112,16 @@ export class GraphqlPlaygroundComponent {
         <div id="graphiql">Loading...</div>
       </Host>
     );
+  }
+
+  private getFetcher(configuration: ExternalGraphqlPlaygroundConfiguration) {
+    const fetcherConfig = {
+      url: configuration.endpoint,
+    }
+    if (configuration.headers) {
+      fetcherConfig['headers'] = configuration.headers;
+    }
+    // @ts-ignore
+    return GraphiQL.createFetcher(fetcherConfig);
   }
 }

--- a/ontotext-graphql-playground-component/src/models/external-graphql-playground-configuration.ts
+++ b/ontotext-graphql-playground-component/src/models/external-graphql-playground-configuration.ts
@@ -3,4 +3,8 @@ export class ExternalGraphqlPlaygroundConfiguration {
    * The graphql endpoint which will be used when a query request is made.
    */
   endpoint: string
+  /**
+   * The headers which will be sent with the query request.
+   */
+  headers: Record<string, string>;
 }

--- a/ontotext-graphql-playground-component/src/pages/configuration/index.html
+++ b/ontotext-graphql-playground-component/src/pages/configuration/index.html
@@ -13,6 +13,8 @@
   <body>
     <a href="/">back</a>
     <button id="changeEndpointButton" onclick="changeEndpoint()">change endpoint</button>
+    <button id="addHeadersButton" onclick="addHeaders()">add headers</button>
+    <button id="removeHeadersButton" onclick="removeHeaders()">remove headers</button>
     <hr />
     <div class="content">
       <graphql-playground-component></graphql-playground-component>

--- a/ontotext-graphql-playground-component/src/pages/configuration/main.js
+++ b/ontotext-graphql-playground-component/src/pages/configuration/main.js
@@ -7,3 +7,24 @@ function changeEndpoint() {
     };
   }
 }
+
+function addHeaders() {
+  const graphqlPlayground = getPlaygroundComponent();
+  if (graphqlPlayground) {
+    graphqlPlayground.configuration = {
+      ...getConfiguration(),
+      headers: {
+        'Authorization': 'Bearer 1234567890'
+      }
+    };
+  }
+}
+
+function removeHeaders() {
+  const graphqlPlayground = getPlaygroundComponent();
+  if (graphqlPlayground) {
+    graphqlPlayground.configuration = {
+      ...getConfiguration()
+    };
+  }
+}


### PR DESCRIPTION
## What
Extend the component configuration to allow http headers to be provided.

## Why
We need to be able to pass authorization header when GDB security is enabled.

## How
* Extended configuration model with `headers` property.
* Configured the `fetcher` with the `headers` if provided.
* Implemented test to cover the new functionality.