### PR TITLE
Remove Wrongly Committed File

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml


### PR DESCRIPTION
## What
When checking out the project, IntelliJ does not display all the project files.

## Why
A .gitignore file is committed inside the .idea folder. When the project is cloned, the .idea folder is created in the project directory, and IntelliJ might not have fully initialized the project settings.

## How
Remove the .gitignore file from the .idea folder. This will prevent the creation of the .idea folder, allowing IntelliJ to create it correctly when the project is opened for the first time.