### PR TITLE
GDB-11239: Internationalize the ontotext-graphql-playground Component

### DIFF
--- a/ontotext-graphql-playground-component/cypress/e2e/translation.spec.cy.ts
+++ b/ontotext-graphql-playground-component/cypress/e2e/translation.spec.cy.ts
@@ -1,0 +1,59 @@
+import { TranslationPageSteps } from '../steps/translation-page-steps';
+import {GraphiqlPlaygroundSteps} from '../steps/graphiql-playground-steps';
+import {GraphiQLEditorToolsSteps} from '../steps/graphiql-editor-tools-steps';
+
+describe('Internationalization', () => {
+  beforeEach(() => {
+    TranslationPageSteps.visit();
+  });
+  
+  it('Should use the selected language passed as configuration', () => {
+    // Given: I have visited a page containing the GraphiQL playground.
+    GraphiqlPlaygroundSteps.getPlayground().should('be.visible');
+    GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('Headers');
+    
+    // When: I change the selected language passed as configuration to "fr".
+    TranslationPageSteps.configureFrenchLanguage();
+    
+    // Then: I expect the GraphiQL interface to be translated into French.
+    GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('En-têtes')
+  });
+  
+  it('Should change the selected language via "setLanguage" method', () => {
+    // Given: I have visited a page containing the GraphiQL playground.
+    GraphiqlPlaygroundSteps.getPlayground().should('be.visible');
+    GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('Headers');
+    
+    // When: I change the selected language via the "setLanguage" method to "fr".
+    TranslationPageSteps.setFrenchLanguage();
+    
+    // Then: I expect the GraphiQL interface to be translated into French.
+    GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('En-têtes')
+  });
+  
+  it('Should be possible to add more languages', () => {
+    // Given: I have visited a page containing the GraphiQL playground,
+    GraphiqlPlaygroundSteps.getPlayground().should('be.visible');
+    GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('Headers');
+    // and it is configured with additional languages.
+    TranslationPageSteps.addMoreLanguages();
+    
+    // When: I change the selected language to "br" (Bulgarian).
+    TranslationPageSteps.setBulgarianLanguage();
+    
+    // Then: I expect the GraphiQL interface to be translated into Bulgarian.
+    GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('Заглавки')
+  });
+  
+  it('Should be possible to override translations through configuration', () => {
+    // Given: I have visited a page containing the GraphiQL playground.
+    GraphiqlPlaygroundSteps.getPlayground().should('be.visible');
+    GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('Headers');
+    
+    // When: I configure it with a translation that overrides the internally defined translation.
+    TranslationPageSteps.configureOverrideTranslationButton();
+    
+    // Then: I expect the GraphiQL component to use the overridden label.
+    GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('Headers Changed from External Configuration');
+  });
+});

--- a/ontotext-graphql-playground-component/cypress/steps/graphiql-editor-tools-steps.ts
+++ b/ontotext-graphql-playground-component/cypress/steps/graphiql-editor-tools-steps.ts
@@ -1,0 +1,11 @@
+/// <reference types="cypress" />
+export class GraphiQLEditorToolsSteps {
+  
+  static getGraphiQLEditorTools(): Cypress.Chainable {
+    return cy.get(".graphiql-editor-tools");
+  }
+  
+  static getGraphiQLEditorTabButton(index: number): Cypress.Chainable {
+    return GraphiQLEditorToolsSteps.getGraphiQLEditorTools().find('button').eq(index);
+  }
+}

--- a/ontotext-graphql-playground-component/cypress/steps/graphiql-playground-steps.ts
+++ b/ontotext-graphql-playground-component/cypress/steps/graphiql-playground-steps.ts
@@ -1,0 +1,7 @@
+/// <reference types="cypress" />
+export class GraphiqlPlaygroundSteps {
+  
+  static getPlayground(): Cypress.Chainable {
+    return cy.get('.graphiql-query-editor');
+  }
+}

--- a/ontotext-graphql-playground-component/cypress/steps/translation-page-steps.ts
+++ b/ontotext-graphql-playground-component/cypress/steps/translation-page-steps.ts
@@ -1,0 +1,51 @@
+/// <reference types="cypress" />
+export class TranslationPageSteps {
+  
+  static visit(): void {
+    cy.visit('/pages/translation');
+  }
+  
+  static getUseFrenchLanguageInConfigurationButton(): Cypress.Chainable {
+    return cy.get('#useFrenchLanguageInConfigurationButton');
+  }
+  
+  static configureFrenchLanguage() {
+    TranslationPageSteps.getUseFrenchLanguageInConfigurationButton().click();
+  }
+  
+  static getAddMoreLanguagesButton(): Cypress.Chainable {
+    return cy.get('#addMoreLanguagesButton');
+  }
+  
+  static addMoreLanguages() {
+    TranslationPageSteps.getAddMoreLanguagesButton().click();
+  }
+  
+  static getSetOverrideTranslationButton(): Cypress.Chainable {
+    return cy.get('#setOverrideTranslationButton');
+  }
+  
+  static configureOverrideTranslationButton() {
+    TranslationPageSteps.getSetOverrideTranslationButton().click();
+  }
+  
+  static getSetEnglishLanguageButton(): Cypress.Chainable {
+    return cy.get('#setEnglishLanguageButton');
+  }
+  
+  static getSetFrenchLanguageButton(): Cypress.Chainable {
+    return cy.get('#setFrenchLanguageButton');
+  }
+  
+  static setFrenchLanguage() {
+    TranslationPageSteps.getSetFrenchLanguageButton().click();
+  }
+  
+  static getSetBulgarianLanguageButton(): Cypress.Chainable {
+    return cy.get('#setBulgarianLanguageButton');
+  }
+  
+  static setBulgarianLanguage() {
+    TranslationPageSteps.getSetBulgarianLanguageButton().click();
+  }
+}

--- a/ontotext-graphql-playground-component/global.d.ts
+++ b/ontotext-graphql-playground-component/global.d.ts
@@ -1,0 +1,28 @@
+import {CreateFetcherOptions, Fetcher} from '@fetcher';
+import {GraphiQLProps} from '@graphiql';
+
+declare global {
+  interface Window {
+    React: React,
+    ReactDOM: ReactDOM,
+    GraphiQL: GraphiQL,
+    GraphiQLPluginExplorer: GraphiQLPluginExplorer
+  }
+}
+
+interface ReactDOM {
+  createRoot(element: Element | null): any
+}
+
+interface GraphiQL {
+  createFetcher(fetcherOptions: CreateFetcherOptions): Fetcher
+}
+
+interface React {
+  createElement(type: any, props: GraphiQLProps): any
+}
+
+interface GraphiQLPluginExplorer {
+  explorerPlugin(): any
+}
+export {}

--- a/ontotext-graphql-playground-component/src/components.d.ts
+++ b/ontotext-graphql-playground-component/src/components.d.ts
@@ -10,6 +10,12 @@ export { ExternalGraphqlPlaygroundConfiguration } from "./models/external-graphq
 export namespace Components {
     interface GraphqlPlaygroundComponent {
         "configuration": ExternalGraphqlPlaygroundConfiguration;
+        /**
+          * Updates the language used in the GraphiQL component.
+          * @param newLanguage - The new language to be set for the GraphiQL component. If not provided, it defaults to 'en'.
+          * @returns A promise that resolves when the language is updated.
+         */
+        "setLanguage": (newLanguage: string) => Promise<void>;
     }
 }
 declare global {

--- a/ontotext-graphql-playground-component/src/components/graphql-playground-component/readme.md
+++ b/ontotext-graphql-playground-component/src/components/graphql-playground-component/readme.md
@@ -12,6 +12,25 @@
 | `configuration` | --        |             | `ExternalGraphqlPlaygroundConfiguration` | `undefined` |
 
 
+## Methods
+
+### `setLanguage(newLanguage: string) => Promise<void>`
+
+Updates the language used in the GraphiQL component.
+
+#### Parameters
+
+| Name          | Type     | Description                                                                                    |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `newLanguage` | `string` | - The new language to be set for the GraphiQL component. If not provided, it defaults to 'en'. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+A promise that resolves when the language is updated.
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/ontotext-graphql-playground-component/src/index.html
+++ b/ontotext-graphql-playground-component/src/index.html
@@ -10,6 +10,7 @@
   <ul>
     <li><a href="/pages/default-view">default view</a></li>
     <li><a href="/pages/configuration">configuration</a></li>
+    <li><a href="/pages/translation">Translation</a></li>
   </ul>
   </body>
 </html>

--- a/ontotext-graphql-playground-component/src/mappers/fetcher-configuration.mapper.ts
+++ b/ontotext-graphql-playground-component/src/mappers/fetcher-configuration.mapper.ts
@@ -1,0 +1,26 @@
+import {ExternalGraphqlPlaygroundConfiguration} from '../models/external-graphql-playground-configuration';
+import {CreateFetcherOptions} from '@fetcher';
+
+/**
+ * Utility class for converting an external GraphQL playground configuration into a fetcher configuration compatible with GraphiQL.
+ */
+export class FetcherConfigurationMapper {
+  
+  /**
+   * Converts an external GraphQL playground configuration into a fetcher configuration.
+   *
+   * @param configuration - The external configuration containing the GraphQL endpoint and optional headers.
+   * @returns A fetcher configuration object containing the endpoint URL and headers.
+   */
+  static toFetcherConfiguration(configuration: ExternalGraphqlPlaygroundConfiguration): CreateFetcherOptions {
+    const fetcherConfig = {
+      url: configuration.endpoint,
+    }
+    // If headers are provided, add them to the fetcher configuration. We currently just pass them as they are without
+    // any validation.
+    if (configuration.headers) {
+      fetcherConfig['headers'] = configuration.headers;
+    }
+    return fetcherConfig;
+  }
+}

--- a/ontotext-graphql-playground-component/src/mappers/graphiql-configuration.mapper.ts
+++ b/ontotext-graphql-playground-component/src/mappers/graphiql-configuration.mapper.ts
@@ -1,0 +1,27 @@
+import {ExternalGraphqlPlaygroundConfiguration} from '../models/external-graphql-playground-configuration';
+import {GraphiQLProps} from '@graphiql';
+import {FetcherConfigurationMapper} from './fetcher-configuration.mapper';
+
+/**
+ * Mapper class for converting an external GraphQL playground configuration into a configuration compatible with GraphiQL.
+ */
+export class GraphiqlConfigurationMapper {
+  
+  /**
+   * Converts an external configuration into a GraphiQL configuration, which is used when initializing the GraphiQL component.
+   *
+   * @param configuration - The external configuration that configures the GraphiQL component.
+   
+   * @returns A GraphiQL configuration object.
+   */
+  static toGraphiQLConfiguration(configuration: ExternalGraphqlPlaygroundConfiguration): GraphiQLProps {
+    return {
+      defaultEditorToolsVisibility: false,
+      selectedLanguage: configuration.selectedLanguage || 'en',
+      defaultQuery: ' ',
+      translations: configuration.translations,
+      fetcher: window.GraphiQL.createFetcher(FetcherConfigurationMapper.toFetcherConfiguration(configuration)),
+      plugins: [window.GraphiQLPluginExplorer.explorerPlugin()]
+    };
+  }
+}

--- a/ontotext-graphql-playground-component/src/models/external-graphql-playground-configuration.ts
+++ b/ontotext-graphql-playground-component/src/models/external-graphql-playground-configuration.ts
@@ -1,3 +1,5 @@
+import {Translations} from './translations';
+
 export class ExternalGraphqlPlaygroundConfiguration {
   /**
    * The graphql endpoint which will be used when a query request is made.
@@ -7,4 +9,37 @@ export class ExternalGraphqlPlaygroundConfiguration {
    * The headers which will be sent with the query request.
    */
   headers: Record<string, string>;
+  
+  /**
+   * Determines the language that has to be used. If none is provided, the default ('en') will be used.
+   */
+  selectedLanguage?: string;
+  
+  /**
+   * Represents a collection of translations for multiple languages,
+   * using a flat structure with dot-separated keys or nested objects.
+   *
+   * If no translations are provided, the internally defined translations for English (`en`)
+   * and French (`fr`) will be used. If translations are passed, they will extend or override
+   * the predefined ones.
+   *
+   * @example
+   * ```typescript
+   * const translations: Translations = {
+   *   en: {
+   *     "editor.title": "Editor",
+   *     "editor": {
+   *       "description": "This is the editor"
+   *     }
+   *   },
+   *   fr: {
+   *     "editor.title": "Éditeur",
+   *     "editor": {
+   *       "description": "C'est l'éditeur"
+   *     }
+   *   }
+   * };
+   * ```
+   */
+  translations?: Translations;
 }

--- a/ontotext-graphql-playground-component/src/models/translations.ts
+++ b/ontotext-graphql-playground-component/src/models/translations.ts
@@ -1,0 +1,43 @@
+/**
+ * Represents a flat key-value pair translation structure.
+ * The keys can either be dot-separated paths or nested objects.
+ *
+ * @example
+ * ```typescript
+ * const translation: Translation = {
+ *   "editor.title": "Editor",
+ *   "editor": {
+ *     "description": "This is the editor"
+ *   }
+ * };
+ * ```
+ */
+export interface Translation {
+  [key: string]: string | Translation;
+}
+
+/**
+ * Represents a collection of translations for multiple languages,
+ * using a flat structure with dot-separated keys or nested objects.
+ *
+ * @example
+ * ```typescript
+ * const translations: Translations = {
+ *   en: {
+ *     "editor.title": "Editor",
+ *     "editor": {
+ *       "description": "This is the editor"
+ *     }
+ *   },
+ *   fr: {
+ *     "editor.title": "Éditeur",
+ *     "editor": {
+ *       "description": "C'est l'éditeur"
+ *     }
+ *   }
+ * };
+ * ```
+ */
+export interface Translations {
+  [language: string]: Translation;
+}

--- a/ontotext-graphql-playground-component/src/pages/translation/index.html
+++ b/ontotext-graphql-playground-component/src/pages/translation/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <title>Stencil Component Starter</title>
+    <script type="module" src="/build/ontotext-graphql-playground-component.esm.js"></script>
+    <script nomodule src="/build/ontotext-graphql-playground-component.js"></script>
+
+    <script src="./translation/main.js"></script>
+    <script src="./main.js"></script>
+  </head>
+  <body>
+    <a href="/">back</a>
+    <button id="useFrenchLanguageInConfigurationButton" onclick="useFrenchLanguageInConfiguration()">Configure French</button>
+    <button id="addMoreLanguagesButton" onclick="addMoreLanguages()">Add More Languages</button>
+    <button id="setOverrideTranslationButton" onclick="setOverrideTranslation()">Set Override translation</button>
+    <button id="setEnglishLanguageButton" onclick="setEnglishLanguage()">Set English</button>
+    <button id="setFrenchLanguageButton" onclick="setFrenchLanguage()">Set French</button>
+    <button id="setBulgarianLanguageButton" onclick="setBulgarianLanguage()">Set Bulgarian</button>
+    <hr />
+    <div class="content">
+      <graphql-playground-component></graphql-playground-component>
+    </div>
+  </body>
+</html>

--- a/ontotext-graphql-playground-component/src/pages/translation/main.js
+++ b/ontotext-graphql-playground-component/src/pages/translation/main.js
@@ -1,0 +1,58 @@
+const useFrenchLanguageInConfiguration = () => {
+    const graphqlPlayground = getPlaygroundComponent();
+    if (graphqlPlayground) {
+        graphqlPlayground.configuration = {
+            ...graphqlPlayground.configuration,
+            selectedLanguage: "fr"
+        };
+    }
+}
+
+const addMoreLanguages = () => {
+    const graphqlPlayground = getPlaygroundComponent();
+    if (graphqlPlayground) {
+        graphqlPlayground.configuration = {
+            ...graphqlPlayground.configuration,
+            translations: {
+                bg: {
+                    "graphiql.editor.tools.btn.headers.label": "Заглавки"
+                }
+            }
+        };
+    }
+}
+
+const setOverrideTranslation = () => {
+    const graphqlPlayground = getPlaygroundComponent();
+    if (graphqlPlayground) {
+        graphqlPlayground.configuration = {
+            ...graphqlPlayground.configuration,
+            translations: {
+                en: {
+                    "graphiql.editor.tools.btn.headers.label": "Headers Changed from External Configuration"
+                }
+            }
+        };
+    }
+}
+
+const setEnglishLanguage = () => {
+    const graphqlPlayground = getPlaygroundComponent();
+    if (graphqlPlayground) {
+        graphqlPlayground.setLanguage("en");
+    }
+}
+
+const setFrenchLanguage = () => {
+    const graphqlPlayground = getPlaygroundComponent();
+    if (graphqlPlayground) {
+        graphqlPlayground.setLanguage("fr");
+    }
+}
+
+const setBulgarianLanguage = () => {
+    const graphqlPlayground = getPlaygroundComponent();
+    if (graphqlPlayground) {
+        graphqlPlayground.setLanguage("bg");
+    }
+}

--- a/ontotext-graphql-playground-component/src/utils/resource-util.ts
+++ b/ontotext-graphql-playground-component/src/utils/resource-util.ts
@@ -1,0 +1,49 @@
+/**
+ * Utility class for dynamically loading external JavaScript and CSS files into a webpage.
+ */
+export class ResourceUtil {
+  
+  /**
+   * Dynamically loads a JavaScript file into the document if it has not been loaded already.
+   *
+   * @param {string} url - The URL of the JavaScript file to load.
+   * @param {boolean} [async=false] - Whether the script should be loaded asynchronously.
+   * @returns {Promise<void>} A promise that resolves when the script is successfully loaded, or rejects if the script fails to load.
+   */
+  static loadJavaScript(url: string, async = false): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (!document.querySelector(`script[src="${url}"]`)) {
+        const loader = document.createElement('script');
+        loader.setAttribute('src', url);
+        loader.async = async;
+        loader.addEventListener('load', () => resolve());
+        loader.addEventListener('error', () => {
+          console.error(`Failed to load script: ${url}`);
+          reject(new Error(`Failed to load script: ${url}`));
+        });
+        document.head.appendChild(loader);
+      } else {
+        resolve();
+      }
+    });
+  }
+  
+  /**
+   * Dynamically loads a CSS file into the document if it has not been loaded already.
+   *
+   * @param {string} url - The URL of the CSS file to load.
+   * @returns {Promise<void>} A promise that resolves immediately after adding the CSS file.
+   */
+  static loadCss(url: string): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (!document.querySelector(`link[href="${url}"]`)) {
+        const loader = document.createElement('link');
+        loader.setAttribute('href', url);
+        loader.rel = 'stylesheet';
+        loader.type = 'text/css';
+        document.head.appendChild(loader);
+      }
+      resolve();
+    });
+  }
+}

--- a/ontotext-graphql-playground-component/tsconfig.json
+++ b/ontotext-graphql-playground-component/tsconfig.json
@@ -14,10 +14,15 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "h",
+    "paths": {
+      "@graphiql": ["../graphiql/packages/graphiql/esm/index.d.ts"],
+      "@fetcher": ["../graphiql/packages/graphiql-toolkit/dist/esm/create-fetcher/types.d.mts"]
+    }
   },
   "include": [
-    "src"
+    "src",
+    "global.d.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## What
Internationalized the ontotext-graphql-playground component.

## Why
The ontotext-graphql-playground component must support multiple languages.

## How
- Extended the graphql-playground component configuration:
 - Added a configuration option to determine which language to use.
 - Added translation support to allow new languages or override internal labels.
- Exposed a new method, setLanguage, which allows changing the language without reloading the entire GraphiQL component.

### Additional work
Reorganized the graphql-playground-component code to separate different functionalities and reduce its functional responsibilities:
- Extracted the logic that maps external configurations to GraphiQL component configurations into separate mappers.
- Extracted types corresponding to GraphiQL components and configurations used in graphql-playground-component to minimize the usage of @ts-ignore.