### PR TITLE
Extends ontotext-graphql-playground component to support codemirror theme

### DIFF
--- a/ontotext-graphql-playground-component/.gitignore
+++ b/ontotext-graphql-playground-component/.gitignore
@@ -26,3 +26,5 @@ UserInterfaceState.xcuserstate
 .env
 /generated/
 /src/components/assets/
+
+/cypress/screenshots/

--- a/ontotext-graphql-playground-component/cypress/e2e/editors-theme.spec.cy.ts
+++ b/ontotext-graphql-playground-component/cypress/e2e/editors-theme.spec.cy.ts
@@ -1,0 +1,55 @@
+import {ThemesSteps} from '../steps/themes-steps';
+import PlaygroundEditorSteps from '../steps/playground-editor-steps';
+import {GraphiqlPlaygroundSteps} from "../steps/graphiql-playground-steps";
+
+describe('Editors Theme', () => {
+  beforeEach(() => {
+    ThemesSteps.visit();
+    // Wait for GraphiQL playground to be fully rendered.
+    GraphiqlPlaygroundSteps.getPlayground().should('be.visible');
+  });
+
+  it('should configure editors theme when theme is set as configuration', () => {
+    // GIVEN: I have visited a page containing the GraphiQL playground.
+    // WHEN: I configure it with a theme.
+    ThemesSteps.configureOceanicNextTheme();
+    // THEN: the "oceanic-next" theme class should be applied to the CodeMirror instances.
+    verifyTheme('oceanic-next');
+  });
+
+  it('should configure default editors theme when theme is not set as configuration', () => {
+    // GIVEN: I have visited a page containing the GraphiQL playground.
+    ThemesSteps.configureOceanicNextTheme();
+
+    // WHEN: I configure it without a theme.
+    ThemesSteps.configureWithoutTheme();
+    // THEN: the default "graphiql" theme class should be applied to the CodeMirror instances.
+    verifyTheme('graphiql');
+  });
+
+  it('should configure editors theme when method setEditorsTheme is called with a theme name', () => {
+    // GIVEN: I have visited a page containing the GraphiQL playground.
+    // WHEN: I change theme.
+    ThemesSteps.setDraculaTheme();
+    // THEN: the "dracula" theme class should be applied to the CodeMirror instances.
+    verifyTheme('dracula');
+  })
+
+  it('should configure editors default theme when method setEditorsTheme is called without theme', () => {
+    // GIVEN: I have visited a page containing the GraphiQL playground.
+    ThemesSteps.setDraculaTheme();
+    // WHEN: I change the theme.
+    ThemesSteps.setDefaultTheme();
+    // THEN: the default "graphiql" theme class should be applied to the CodeMirror instances.
+    verifyTheme('graphiql');
+  })
+
+  const verifyTheme = (theme: string) => {
+    PlaygroundEditorSteps.getResponseCodeMirror().should('have.class', `cm-s-${theme}`);
+    PlaygroundEditorSteps.getGraphiqlEditorsCodeMirror().should('have.class', `cm-s-${theme}`);
+    PlaygroundEditorSteps.openVariables();
+    PlaygroundEditorSteps.getActiveGraphiqlEditorToolCodeMirror().should('have.class', `cm-s-${theme}`);
+    PlaygroundEditorSteps.openHeaders();
+    PlaygroundEditorSteps.getActiveGraphiqlEditorToolCodeMirror().should('have.class', `cm-s-${theme}`);
+  }
+})

--- a/ontotext-graphql-playground-component/cypress/steps/playground-editor-steps.ts
+++ b/ontotext-graphql-playground-component/cypress/steps/playground-editor-steps.ts
@@ -33,12 +33,52 @@ export default class PlaygroundEditorSteps {
     cy.wait(delay);
     return PlaygroundEditorSteps.getExecuteButton().click();
   }
-  
+
   static abortQuery(): void {
     PlaygroundEditorSteps.getExecuteButton().click();
   }
 
   static getResponse(): Cypress.Chainable {
     return cy.get('.graphiql-response');
+  }
+
+  static getResponseCodeMirror(): Cypress.Chainable {
+    return PlaygroundEditorSteps.getResponse().find('.CodeMirror');
+  }
+
+  static getGraphiqlEditors(): Cypress.Chainable {
+    return cy.get('.graphiql-editors');
+  }
+
+  static getGraphiqlEditorsCodeMirror(): Cypress.Chainable {
+    return PlaygroundEditorSteps.getGraphiqlEditors().find('.CodeMirror');
+  }
+
+  static getGraphiqlEditorTools(): Cypress.Chainable {
+    return cy.get('.graphiql-editor-tools');
+  }
+
+  static getGraphiqlEditorTool(): Cypress.Chainable {
+    return cy.get('.graphiql-editor-tool');
+  }
+
+  static getVariablesBtn(): Cypress.Chainable {
+    return PlaygroundEditorSteps.getGraphiqlEditorTools().find('button[data-name="variables"]');
+  }
+
+  static openVariables(): void {
+    PlaygroundEditorSteps.getVariablesBtn().click();
+  }
+
+  static getHeadersBtn(): Cypress.Chainable {
+    return PlaygroundEditorSteps.getGraphiqlEditorTools().find('button[data-name="headers"]');
+  }
+
+  static openHeaders(): void {
+    PlaygroundEditorSteps.getHeadersBtn().click();
+  }
+
+  static getActiveGraphiqlEditorToolCodeMirror(): Cypress.Chainable {
+    return PlaygroundEditorSteps.getGraphiqlEditorTool().find('.graphiql-editor:not(.hidden) .CodeMirror');
   }
 }

--- a/ontotext-graphql-playground-component/cypress/steps/themes-steps.ts
+++ b/ontotext-graphql-playground-component/cypress/steps/themes-steps.ts
@@ -1,0 +1,37 @@
+export class ThemesSteps {
+  static visit() {
+    cy.visit('/pages/themes');
+  }
+  
+  static getConfigureWithoutThemeBtn() {
+    return cy.get('#configureWithoutTheme');
+  }
+  
+  static configureWithoutTheme() {
+    ThemesSteps.getConfigureWithoutThemeBtn().click();
+  }
+  
+  static getConfigureOceanicNextThemeBtn() {
+    return cy.get('#configureOceanicNextTheme');
+  }
+  
+  static configureOceanicNextTheme() {
+    ThemesSteps.getConfigureOceanicNextThemeBtn().click();
+  }
+  
+  static getSetDefaultThemeButton() {
+    return cy.get('#setDefaultTheme');
+  }
+  
+  static setDefaultTheme() {
+    ThemesSteps.getSetDefaultThemeButton().click();
+  }
+  
+  static getSetDraculaThemeButton() {
+    return cy.get('#setDraculaTheme');
+  }
+  
+  static setDraculaTheme() {
+    ThemesSteps.getSetDraculaThemeButton().click();
+  }
+}

--- a/ontotext-graphql-playground-component/src/components.d.ts
+++ b/ontotext-graphql-playground-component/src/components.d.ts
@@ -11,6 +11,12 @@ export namespace Components {
     interface GraphqlPlaygroundComponent {
         "configuration": ExternalGraphqlPlaygroundConfiguration;
         /**
+          * Sets the CodeMirror theme for all GraphiQL editor instances.  Updates the editor theme in the current GraphiQL configuration and re-renders GraphiQL to apply the new theme.
+          * @param editorsThemeName - Name of the CodeMirror theme to apply. Defaults to `"graphiql"` if not provided.
+          * @returns A resolved promise once the theme is applied.
+         */
+        "setEditorsTheme": (editorsThemeName?: string) => Promise<void>;
+        /**
           * Updates the language used in the GraphiQL component.
           * @param newLanguage - The new language to be set for the GraphiQL component. If not provided, it defaults to 'en'.
           * @returns A promise that resolves when the language is updated.

--- a/ontotext-graphql-playground-component/src/components/graphql-playground-component/graphql-playground-component.tsx
+++ b/ontotext-graphql-playground-component/src/components/graphql-playground-component/graphql-playground-component.tsx
@@ -3,7 +3,9 @@ import {ExternalGraphqlPlaygroundConfiguration} from "../../models/external-grap
 import {GraphiQLProps} from '@graphiql';
 import {ResourceUtil} from '../../utils/resource-util';
 import {GraphiqlConfigurationMapper} from '../../mappers/graphiql-configuration.mapper';
-import {InternalGraphqlPlaygroundConfiguration} from '../../models/internal-graphql-playground-configuration';
+import {
+  InternalGraphqlPlaygroundConfiguration
+} from '../../models/internal-graphql-playground-configuration';
 
 @Component({
   tag: 'graphql-playground-component',
@@ -14,7 +16,7 @@ import {InternalGraphqlPlaygroundConfiguration} from '../../models/internal-grap
 export class GraphqlPlaygroundComponent {
   // React root instance must be created only once and reused
   private reactRoot: any;
-  
+
   /**
    * React determines whether a component should re-render by checking references for equality.
    * This property holds a reference to the entire configuration when GraphiQL is first created.
@@ -24,19 +26,19 @@ export class GraphqlPlaygroundComponent {
    * the language works.
    */
   private graphiQlConfiguration: GraphiQLProps;
-  
+
   @Prop() configuration: ExternalGraphqlPlaygroundConfiguration;
-  
+
   @Watch('configuration')
   configurationChanged(configuration: ExternalGraphqlPlaygroundConfiguration) {
     this.init(configuration);
   }
-  
+
   /**
    * An event is emitted when a query is aborted, with the initialized request data as the payload.
    */
   @Event() abortQuery: EventEmitter<RequestInit>;
-  
+
   /**
    * Updates the language used in the GraphiQL component.
    *
@@ -52,7 +54,26 @@ export class GraphqlPlaygroundComponent {
     }
     return Promise.resolve();
   }
-  
+
+  /**
+   * Sets the CodeMirror theme for all GraphiQL editor instances.
+   *
+   * Updates the editor theme in the current GraphiQL configuration and
+   * re-renders GraphiQL to apply the new theme.
+   *
+   * @param editorsThemeName - Name of the CodeMirror theme to apply.
+   * Defaults to `"graphiql"` if not provided.
+   * @returns A resolved promise once the theme is applied.
+   */
+  @Method()
+  setEditorsTheme(editorsThemeName = 'graphiql'): Promise<void> {
+    if (this.graphiQlConfiguration) {
+      this.graphiQlConfiguration.editorTheme = editorsThemeName;
+      this.renderGraphiQL();
+    }
+    return Promise.resolve();
+  }
+
   async componentWillLoad(): Promise<void> {
     const basePath = './assets/';
     try {
@@ -60,14 +81,14 @@ export class GraphqlPlaygroundComponent {
       await ResourceUtil.loadJavaScript(getAssetPath(`${basePath}react-dom.development.js`));
       await ResourceUtil.loadJavaScript(getAssetPath(`${basePath}graphiql.min.js`));
       await ResourceUtil.loadJavaScript(getAssetPath(`${basePath}explorer.index.umd.js`));
-      
+
       await ResourceUtil.loadCss(getAssetPath(`${basePath}graphiql.min.css`));
       await ResourceUtil.loadCss(getAssetPath(`${basePath}explorer.style.css`));
     } catch (error) {
       console.error('Error loading assets:', error);
     }
   }
-  
+
   componentDidLoad(): void {
     setTimeout(() => {
       if (this.configuration) {
@@ -77,14 +98,14 @@ export class GraphqlPlaygroundComponent {
       }
     }, 500);
   }
-  
+
   disconnectedCallback() {
     if (this.reactRoot) {
       this.reactRoot.unmount();
       this.reactRoot = null;
     }
   }
-  
+
   render(): JSX.Element {
     return (
       <Host>
@@ -92,11 +113,11 @@ export class GraphqlPlaygroundComponent {
       </Host>
     );
   }
-  
+
   private init(externalConfiguration: ExternalGraphqlPlaygroundConfiguration) {
     const configuration = new InternalGraphqlPlaygroundConfiguration(externalConfiguration);
     configuration.onAbortQuery = (request: RequestInit) => this.abortQuery.emit(request);
-    
+
     const containerEl = document.querySelector('graphql-playground-component #graphiql');
     if (!containerEl) {
       console.error('Container element not found');
@@ -106,11 +127,11 @@ export class GraphqlPlaygroundComponent {
       // Create the root only once
       this.reactRoot = window.ReactDOM.createRoot(containerEl);
     }
-    
+
     this.graphiQlConfiguration = GraphiqlConfigurationMapper.toGraphiQLConfiguration(configuration);
     this.renderGraphiQL();
   }
-  
+
   private renderGraphiQL(): void {
     this.reactRoot.render(
       window.React.createElement(window.GraphiQL, this.graphiQlConfiguration),

--- a/ontotext-graphql-playground-component/src/components/graphql-playground-component/readme.md
+++ b/ontotext-graphql-playground-component/src/components/graphql-playground-component/readme.md
@@ -21,6 +21,25 @@
 
 ## Methods
 
+### `setEditorsTheme(editorsThemeName?: string) => Promise<void>`
+
+Sets the CodeMirror theme for all GraphiQL editor instances.
+
+Updates the editor theme in the current GraphiQL configuration and
+re-renders GraphiQL to apply the new theme.
+
+#### Parameters
+
+| Name               | Type     | Description                                                                        |
+| ------------------ | -------- | ---------------------------------------------------------------------------------- |
+| `editorsThemeName` | `string` | - Name of the CodeMirror theme to apply. Defaults to `"graphiql"` if not provided. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+A resolved promise once the theme is applied.
+
 ### `setLanguage(newLanguage: string) => Promise<void>`
 
 Updates the language used in the GraphiQL component.

--- a/ontotext-graphql-playground-component/src/index.html
+++ b/ontotext-graphql-playground-component/src/index.html
@@ -12,6 +12,7 @@
     <li><a href="/pages/configuration">configuration</a></li>
     <li><a href="/pages/translation">Translation</a></li>
     <li><a href="/pages/abort-query">Abort query</a></li>
+    <li><a href="/pages/themes">Editors Themes</a></li>
   </ul>
   </body>
 </html>

--- a/ontotext-graphql-playground-component/src/mappers/graphiql-configuration.mapper.ts
+++ b/ontotext-graphql-playground-component/src/mappers/graphiql-configuration.mapper.ts
@@ -18,6 +18,7 @@ export class GraphiqlConfigurationMapper {
     return {
       defaultEditorToolsVisibility: false,
       selectedLanguage: configuration.selectedLanguage,
+      editorTheme: configuration.editorsThemeName,
       defaultQuery: configuration.defaultQuery,
       translations: configuration.translations,
       fetcher: window.GraphiQL.createFetcher(FetcherConfigurationMapper.toFetcherConfiguration(configuration)),

--- a/ontotext-graphql-playground-component/src/models/external-graphql-playground-configuration.ts
+++ b/ontotext-graphql-playground-component/src/models/external-graphql-playground-configuration.ts
@@ -18,6 +18,13 @@ export class ExternalGraphqlPlaygroundConfiguration {
   selectedLanguage?: string;
   
   /**
+   * Name of the CodeMirror theme applied to all GraphiQL editor instances.
+   *
+   * If this property is not provided, the default `"graphiql"` theme is used.
+   */
+  editorsThemeName?: string;
+  
+  /**
    * Represents a collection of translations for multiple languages,
    * using a flat structure with dot-separated keys or nested objects.
    *

--- a/ontotext-graphql-playground-component/src/models/internal-graphql-playground-configuration.ts
+++ b/ontotext-graphql-playground-component/src/models/internal-graphql-playground-configuration.ts
@@ -13,12 +13,19 @@ export class InternalGraphqlPlaygroundConfiguration {
    * - If provided as a function (`() => Record<string, string>`), the function will be called to generate the headers dynamically.
    */
   headers: Record<string, string> | (() => Record<string, string>);
-  
+
   /**
    * Determines the language that has to be used. If none is provided, the default ('en') will be used.
    */
   selectedLanguage?: string;
-  
+
+  /**
+   * Name of the CodeMirror theme applied to all GraphiQL editor instances.
+   *
+   * If this property is not provided, the default `"graphiql"` theme is used.
+   */
+  editorsThemeName?: string;
+
   /**
    * Represents a collection of translations for multiple languages,
    * using a flat structure with dot-separated keys or nested objects.
@@ -46,24 +53,25 @@ export class InternalGraphqlPlaygroundConfiguration {
    * ```
    */
   translations?: Translations;
-  
+
   /**
    * The default query that will be used when a new tab is added.
    */
   defaultQuery: string;
-  
+
   /**
    * Callback function invoked when a query is aborted.
    *
    * @param response - The initialized request data associated with the aborted query.
    */
   onAbortQuery?: (response: RequestInit) => void;
-  
+
   constructor(externalConfiguration: ExternalGraphqlPlaygroundConfiguration) {
     this.endpoint = externalConfiguration.endpoint;
     this.headers = externalConfiguration.headers;
     this.selectedLanguage = externalConfiguration.selectedLanguage || 'en';
     this.translations = externalConfiguration.translations;
     this.defaultQuery = externalConfiguration.defaultQuery || ' ';
+    this.editorsThemeName = externalConfiguration.editorsThemeName;
   }
 }

--- a/ontotext-graphql-playground-component/src/pages/themes/dracula.css
+++ b/ontotext-graphql-playground-component/src/pages/themes/dracula.css
@@ -1,0 +1,40 @@
+/*
+
+Name:       dracula
+Author:     Michael Kaminsky (http://github.com/mkaminsky11)
+
+Original dracula color scheme by Zeno Rocha (https://github.com/zenorocha/dracula-theme)
+
+*/
+
+
+.cm-s-dracula.CodeMirror, .cm-s-dracula .CodeMirror-gutters {
+    background-color: #282a36 !important;
+    color: #f8f8f2 !important;
+    border: none;
+}
+.cm-s-dracula .CodeMirror-gutters { color: #282a36; }
+.cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
+.cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
+.cm-s-dracula .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula span.cm-comment { color: #6272a4; }
+.cm-s-dracula span.cm-string, .cm-s-dracula span.cm-string-2 { color: #f1fa8c; }
+.cm-s-dracula span.cm-number { color: #bd93f9; }
+.cm-s-dracula span.cm-variable { color: #50fa7b; }
+.cm-s-dracula span.cm-variable-2 { color: white; }
+.cm-s-dracula span.cm-def { color: #50fa7b; }
+.cm-s-dracula span.cm-operator { color: #ff79c6; }
+.cm-s-dracula span.cm-keyword { color: #ff79c6; }
+.cm-s-dracula span.cm-atom { color: #bd93f9; }
+.cm-s-dracula span.cm-meta { color: #f8f8f2; }
+.cm-s-dracula span.cm-tag { color: #ff79c6; }
+.cm-s-dracula span.cm-attribute { color: #50fa7b; }
+.cm-s-dracula span.cm-qualifier { color: #50fa7b; }
+.cm-s-dracula span.cm-property { color: #66d9ef; }
+.cm-s-dracula span.cm-builtin { color: #50fa7b; }
+.cm-s-dracula span.cm-variable-3, .cm-s-dracula span.cm-type { color: #ffb86c; }
+
+.cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1); }
+.cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/ontotext-graphql-playground-component/src/pages/themes/index.html
+++ b/ontotext-graphql-playground-component/src/pages/themes/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <title>Stencil Component Starter</title>
+    <script type="module" src="/build/ontotext-graphql-playground-component.esm.js"></script>
+    <script nomodule src="/build/ontotext-graphql-playground-component.js"></script>
+
+    <script src="./themes/main.js"></script>
+    <link rel="stylesheet" href="../themes/oceanic-next.css" />
+    <link rel="stylesheet" href="./themes/dracula.css" />
+    <script src="./main.js"></script>
+  </head>
+  <body>
+    <a href="/">Back</a>
+    <hr />
+    <button id="configureOceanicNextTheme" onclick="configureOceanicNextTheme()">Configure oceanic-next Theme</button>
+    <button id="configureWithoutTheme" onclick="configureWithoutTheme()">Configure without theme</button>
+    <button id="setDraculaTheme" onclick="setDraculaTheme()">Set dracula Theme</button>
+    <button id="setDefaultTheme" onclick="setDefaultTheme()">Set default Theme</button>
+    <div class="content">
+      <graphql-playground-component></graphql-playground-component>
+    </div>
+  </body>
+</html>

--- a/ontotext-graphql-playground-component/src/pages/themes/main.js
+++ b/ontotext-graphql-playground-component/src/pages/themes/main.js
@@ -1,0 +1,19 @@
+function setDraculaTheme() {
+    const playgroundComponent = getPlaygroundComponent();
+    playgroundComponent.setEditorsTheme('dracula');
+}
+
+function setDefaultTheme() {
+    const playgroundComponent = getPlaygroundComponent();
+    playgroundComponent.setEditorsTheme(undefined);
+}
+
+function configureOceanicNextTheme() {
+    const playgroundComponent = getPlaygroundComponent();
+    playgroundComponent.configuration = {...playgroundComponent.configuration, editorsThemeName: 'oceanic-next'}
+}
+
+function configureWithoutTheme() {
+    const playgroundComponent = getPlaygroundComponent();
+    playgroundComponent.configuration = {...playgroundComponent.configuration, editorsThemeName: undefined}
+}

--- a/ontotext-graphql-playground-component/src/pages/themes/oceanic-next.css
+++ b/ontotext-graphql-playground-component/src/pages/themes/oceanic-next.css
@@ -1,0 +1,46 @@
+/*
+
+    Name:       oceanic-next
+    Author:     Filype Pereira (https://github.com/fpereira1)
+
+    Original oceanic-next color scheme by Dmitri Voronianski (https://github.com/voronianski/oceanic-next-color-scheme)
+
+*/
+
+.cm-s-oceanic-next.CodeMirror { background: #304148; color: #f8f8f2; }
+.cm-s-oceanic-next div.CodeMirror-selected { background: rgba(101, 115, 126, 0.33); }
+.cm-s-oceanic-next .CodeMirror-line::selection, .cm-s-oceanic-next .CodeMirror-line > span::selection, .cm-s-oceanic-next .CodeMirror-line > span > span::selection { background: rgba(101, 115, 126, 0.33); }
+.cm-s-oceanic-next .CodeMirror-line::-moz-selection, .cm-s-oceanic-next .CodeMirror-line > span::-moz-selection, .cm-s-oceanic-next .CodeMirror-line > span > span::-moz-selection { background: rgba(101, 115, 126, 0.33); }
+.cm-s-oceanic-next .CodeMirror-gutters { background: #304148; border-right: 10px; }
+.cm-s-oceanic-next .CodeMirror-guttermarker { color: white; }
+.cm-s-oceanic-next .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
+.cm-s-oceanic-next .CodeMirror-linenumber { color: #d0d0d0; }
+.cm-s-oceanic-next .CodeMirror-cursor { border-left: 1px solid #f8f8f0; }
+.cm-s-oceanic-next.cm-fat-cursor .CodeMirror-cursor { background-color: #a2a8a175 !important; }
+.cm-s-oceanic-next .cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
+
+.cm-s-oceanic-next span.cm-comment { color: #65737E; }
+.cm-s-oceanic-next span.cm-atom { color: #C594C5; }
+.cm-s-oceanic-next span.cm-number { color: #F99157; }
+
+.cm-s-oceanic-next span.cm-property { color: #99C794; }
+.cm-s-oceanic-next span.cm-attribute,
+.cm-s-oceanic-next span.cm-keyword { color: #C594C5; }
+.cm-s-oceanic-next span.cm-builtin { color: #66d9ef; }
+.cm-s-oceanic-next span.cm-string { color: #99C794; }
+
+.cm-s-oceanic-next span.cm-variable,
+.cm-s-oceanic-next span.cm-variable-2,
+.cm-s-oceanic-next span.cm-variable-3 { color: #f8f8f2; }
+.cm-s-oceanic-next span.cm-def { color: #6699CC; }
+.cm-s-oceanic-next span.cm-bracket { color: #5FB3B3; }
+.cm-s-oceanic-next span.cm-tag { color: #C594C5; }
+.cm-s-oceanic-next span.cm-header { color: #C594C5; }
+.cm-s-oceanic-next span.cm-link { color: #C594C5; }
+.cm-s-oceanic-next span.cm-error { background: #C594C5; color: #f8f8f0; }
+
+.cm-s-oceanic-next .CodeMirror-activeline-background { background: rgba(101, 115, 126, 0.33); }
+.cm-s-oceanic-next .CodeMirror-matchingbracket {
+    text-decoration: underline;
+    color: white !important;
+}


### PR DESCRIPTION
## What
Extends ontotext-graphql-playground component with the ability to change the CodeMirror theme used in it.

## Why
This allows clients to adjust the editor’s appearance for better visibility or personal preference, improving usability and readability.

## How
The component now supports changing the editors theme in two ways. Important: The client must load or define the necessary CSS rules for the theme before using the component. This can be done by:
 - Loading a built-in CodeMirror theme CSS file via <link> or import;
 - Defining custom CSS rules targeting .cm-s-{themeName}.CodeMirror and related token classes. Once the CSS is available, the theme name can be set in two ways:
 - Configuration during component creation: Pass the desired theme name in the editorsThemeName configuration when initializing ontotext-yasgui-web-component. The component applies the theme immediately upon creation. -Dynamically after creation: Use the exposed setEditorsTheme(themeName: string) method to change the theme at runtime. This allows the theme to be updated dynamically based on user interaction or other events.

## Screenshots
<img width="2430" height="1102" alt="image" src="https://github.com/user-attachments/assets/a23c0a36-daca-4113-bddd-6e390450f2d8" />
<img width="2430" height="1102" alt="image" src="https://github.com/user-attachments/assets/5b56f5a7-a468-4d8c-b6f3-54c8dfa99f35" />
<img width="2430" height="1102" alt="image" src="https://github.com/user-attachments/assets/0f4901d2-73dd-47a7-a4f1-550d29955257" />





